### PR TITLE
Remove labels from build/push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,4 +41,3 @@ jobs:
           context: "."
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I want to see if "labels" is required for "latest", which was pushed,
but was not specified in the tags.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>
